### PR TITLE
all: make the directories be Go packages

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,3 @@
+package opt
+
+// make this directory a Go package

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/gunk/opt

--- a/http/doc.go
+++ b/http/doc.go
@@ -1,0 +1,3 @@
+package http
+
+// make this directory a Go package


### PR DESCRIPTION
This way, the gunk tool can use regular Go package loading to find these
packages and download them if necessary. That task is otherwise complex
and un-idiomatic.