### PR TITLE
http: added struct field annotations for protobuf

### DIFF
--- a/http/http.gunk
+++ b/http/http.gunk
@@ -3,7 +3,7 @@ package http
 
 // Match is the http matching option.
 type Match struct {
-    Method string
-    Path string
-    Body string
+    Method string `pb:"1"`
+    Path   string `pb:"2"`
+    Body   string `pb:"3"`
 }


### PR DESCRIPTION
The 'http.Match' struct was missing the required protobuf annotations on
the struct fields. Since this is becoming a requirement for gunk
declerations, the 'http.Match' needs to include the protobuf
annotations.

Updates gunk/gunk/issues/34