### PR TITLE
xo: add SkipPrefix package option

### DIFF
--- a/xo/xo.gunk
+++ b/xo/xo.gunk
@@ -27,3 +27,6 @@ type Embed bool
 // Default is the default value option for the corresponding field.
 type Default string 
 
+// SkipPrefix is an option to skip package prefixes when creating the table
+// name.
+type SkipPrefix bool


### PR DESCRIPTION
This PR adds a SkipPrefix package option to the `xo` package which allows the user to specify which packages to skip prefixes for when generating table names.

A struct named `Bar` in `package foo` will get the table name `foo_bar` by default but will instead get the table name `bar` instead if this option is set to true in the package.